### PR TITLE
Use README.rst content as a long description in setup.py

### DIFF
--- a/files/crt/python/lib/setup.py
+++ b/files/crt/python/lib/setup.py
@@ -10,7 +10,7 @@ setup(
     name = 'NAME',
     version = '0.0.1',
     description = 'Short description',
-    long_description = 'Long description',
+    long_description = ''.join(open('README.rst').readlines()),
     keywords = 'some, keywords',
     author = 'yourname',
     author_email = 'yourmail',


### PR DESCRIPTION
We already have a rst formatted README, so use it's content as long description.
