### PR TITLE
Remove dependency on eclipse-rpm-editor

### DIFF
--- a/assistants/crt/c.yaml
+++ b/assistants/crt/c.yaml
@@ -5,7 +5,7 @@ dependencies:
 - rpm: ['gcc', 'glibc-devel', 'automake', 'autoconf', 'valgrind', 'gdb', 'strace']
 
 dependencies_build:
-- rpm: ['rpm-build','mock','rpmdevtools','eclipse-rpm-editor']
+- rpm: ['rpm-build','mock','rpmdevtools']
 
 dependencies_eclipse:
 - use: eclipse.dependencies_c

--- a/assistants/crt/cpp.yaml
+++ b/assistants/crt/cpp.yaml
@@ -5,7 +5,7 @@ dependencies:
 - rpm: ['gcc-c++', 'glibc-devel', 'automake', 'autoconf', 'valgrind', 'gdb', 'strace']
 
 dependencies_build:
-- rpm: ['rpm-build','mock','rpmdevtools','eclipse-rpm-editor']
+- rpm: ['rpm-build','mock','rpmdevtools']
 
 dependencies_eclipse:
 - use: eclipse.dependencies_c


### PR DESCRIPTION
Addresses bkabrda/devassistant-assistants-fedora#22

I don't know if you want this change, so feel free to reject this pull request if there's a reason to require the package that I'm not aware of.
