### PR TITLE
stop validating email addresses

### DIFF
--- a/snippets/git_init_add_commit.yaml
+++ b/snippets/git_init_add_commit.yaml
@@ -14,7 +14,7 @@ run:
     - ask_input:
         prompt: "Your e-mail address, please"
         message: "Your git configuration is incomplete!"
-  - if not $(echo "$email" | grep -q '\w\+@\w\+\.\w\+'):
+  - if not $(echo "$email" | grep -q '.\+@.\+\..\+'):
     - log_e: "Not a valid e-mail address: $email"
   - cl: git config --global user.email "$email"
 


### PR DESCRIPTION
Nice blogpost :)

http://davidcel.is/blog/2012/09/06/stop-validating-email-addresses-with-regex/

$ echo 'harald@harald-hoyer.de' | grep -q '\w+@\w+.\w+' && echo OK
$
$ echo 'harald@harald-hoyer.de' | grep -q '.+@.+..+' && echo OK
OK
